### PR TITLE
Fix static map location encoding

### DIFF
--- a/layouts/shortcodes/map.html
+++ b/layouts/shortcodes/map.html
@@ -52,7 +52,7 @@
      data-src="https://www.google.com/maps/embed/v1/place?key={{ $key }}&q={{ $locEscaped }}&zoom={{ $zoom }}&maptype=roadmap">
 
   <img class="map-thumbnail"
-       src="https://maps.googleapis.com/maps/api/staticmap?center={{ $loc }}&zoom={{ $zoom }}&size=800x450&markers=color:red%7C{{ $loc }}&key={{ $key }}"
+       src="https://maps.googleapis.com/maps/api/staticmap?center={{ $locEscaped }}&zoom={{ $zoom }}&size=800x450&markers=color:red%7C{{ $locEscaped }}&key={{ $key }}"
        alt="Map preview">
 
   {{ if .Site.Params.show_privacy_notice }}


### PR DESCRIPTION
## Summary
- escape location for Google Static Maps

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687df0ce0c08832890744f39496e4335